### PR TITLE
Allow choosing the heading level to use for frames. 

### DIFF
--- a/present.org
+++ b/present.org
@@ -1,6 +1,6 @@
 #+Title: Example Presentation
 #+Author: Eric Schulte
-
+#+EPRESENT_FRAME_LEVEL: 1
 * TODO One -- intro                                             :hello:world:
   :PROPERTIES:
   :ARCHIVE:  hello


### PR DESCRIPTION
Added a new variable `EPRESENT_FRAME_LEVEL` (similar to BEAMER_FRAME_LEVEL) which allows choosing the heading level to use, for frames. 

Headings above the `EPRESENT_FRAME_LEVEL` should show an outline, but `(org-cycle '(16))` doesn't seem to be working. Can you please fix that? 
