### PR TITLE
Show outline for headings at higher than EPRESENT_FRAME_LEVEL

### DIFF
--- a/epresent.el
+++ b/epresent.el
@@ -129,6 +129,8 @@
       (progn
         (epresent-goto-top-level)
         (org-narrow-to-subtree)
+	(show-all)
+	(hide-body)
         (when (>= (org-reduced-level (org-current-level))
                   epresent-frame-level)
           (org-show-subtree)))


### PR DESCRIPTION
The alternative code written by you, is broken, when I go to a previous slide from a lower level heading (level-2) to a higher level one (level-1). 
This patch gives the desired behaviour. 
