### PR TITLE
Add keybindings for live coding

### DIFF
--- a/epresent.el
+++ b/epresent.el
@@ -267,15 +267,15 @@
     ;; hide todos
     (when epresent-hide-todos
       (goto-char (point-min))
-      (while (re-search-forward org-todo-regexp nil t) 
+      (while (re-search-forward org-todo-regexp nil t)
         (push (make-overlay (match-beginning 1) (1+ (match-end 1)))
               epresent-overlays)
         (overlay-put (car epresent-overlays) 'invisible 'epresent-hide)))
     ;; hide tags
     (when epresent-hide-tags
       (goto-char (point-min))
-      (while (re-search-forward 
-              (org-re "^\\*+.*?\\([ \t]+:[[:alnum:]_@#%:]+:\\)[ \r\n]") 
+      (while (re-search-forward
+              (org-re "^\\*+.*?\\([ \t]+:[[:alnum:]_@#%:]+:\\)[ \r\n]")
               nil t)
         (push (make-overlay (match-beginning 1) (match-end 1)) epresent-overlays)
         (overlay-put (car epresent-overlays) 'invisible 'epresent-hide)))
@@ -340,6 +340,8 @@
     ;; within page functions
     (define-key map "c" 'epresent-next-src-block)
     (define-key map "C" 'epresent-previous-src-block)
+    (define-key map "e" 'org-edit-src-code)
+    (define-key map "x" 'org-babel-execute-src-block)
     (define-key map "r" 'epresent-refresh)
     (define-key map "g" 'epresent-refresh)
     ;; global controls


### PR DESCRIPTION
Oi, 
thanks for epresent it is the no-thrills approach to presentations that I was looking for.

I saw you worked on refreshing the buffer when code was executed but I was unable to execute code (C-c C-c din't work when inside epresent-mode), nor was I able to modify it (C-c ') . So I just added some key bindings

```
e for edit the source block
x for executing it
```

The only thing that is missing is that when editing code inside present-mode the cursor is still blank, any pointers on how to fix that? 
