### PR TITLE
Keymap aren't supposed to be autoloaded

### DIFF
--- a/epresent.el
+++ b/epresent.el
@@ -406,7 +406,6 @@
   (epresent-mode)
   (set-buffer-modified-p nil))
 
-;;;###autoload
 (define-key org-mode-map [f12] 'epresent-run)
 
 (provide 'epresent)


### PR DESCRIPTION
Apparently I made a mistake in #7 the autoload makes it fail on my machine and the keybinding is in place when I open org-mode without it.
