### PR TITLE
Fixed erratic latex preview.

### DIFF
--- a/epresent.el
+++ b/epresent.el
@@ -446,7 +446,7 @@
   (let ((org-format-latex-options
          (plist-put (copy-tree org-format-latex-options)
 		    :scale epresent-format-latex-scale)))
-    (org-preview-latex-fragment 16))
+    (org-preview-latex-fragment '(16)))
   ;; fontify the buffer
   (add-to-invisibility-spec '(epresent-hide))
   ;; remove flyspell overlays


### PR DESCRIPTION
This fixes two problems with latex preview:
- rendering of latex was erratic
- and did not work at all when the presentation wasn't started with the point before the first heading.