### PR TITLE
Add page number support.

### DIFF
--- a/epresent.el
+++ b/epresent.el
@@ -88,11 +88,12 @@
 (defvar epresent-hide-todos t)
 (defvar epresent-hide-tags t)
 (defvar epresent-hide-properties t)
+(defvar epresent-page-number 0)
 
 (defvar epresent-frame-level 1)
 (make-variable-frame-local 'epresent-frame-local) ;; Obsolete function?
 
-(defvar epresent-mode-line nil
+(defvar epresent-mode-line '(:eval (int-to-string epresent-page-number))
   "Set the mode-line format. Hides it when nil")
 
 (defvar epresent-src-blocks-visible t
@@ -142,6 +143,12 @@ If nil then source blocks are initially hidden on slide change.")
     (when (and level (> level epresent-frame-level))
       (org-up-heading-all (- level epresent-frame-level)))))
 
+(defun epresent-jump-to-page (num)
+  "Jump directly to a particular page in the presentation."
+  (interactive "npage number: ")
+  (epresent-top)
+  (dotimes (_ (1- num)) (epresent-next-page)))
+
 (defun epresent-current-page ()
   "Present the current outline heading."
   (interactive)
@@ -165,6 +172,7 @@ If nil then source blocks are initially hidden on slide change.")
   (interactive)
   (widen)
   (goto-char (point-min))
+  (setq epresent-page-number 1)
   (epresent-current-page))
 
 (defun epresent-next-page ()
@@ -176,6 +184,7 @@ If nil then source blocks are initially hidden on slide change.")
          epresent-frame-level)
       (outline-next-heading)
     (org-get-next-sibling))
+  (incf epresent-page-number)
   (epresent-current-page))
 
 (defun epresent-previous-page ()
@@ -188,6 +197,8 @@ If nil then source blocks are initially hidden on slide change.")
          epresent-frame-level)
       (outline-previous-heading)
     (org-get-last-sibling))
+  (when (< 1 epresent-page-number)
+    (decf epresent-page-number))
   (epresent-current-page))
 
 (defun epresent-clean-overlays (&optional start end)
@@ -417,6 +428,7 @@ If nil then source blocks are initially hidden on slide change.")
     (define-key map "b" 'epresent-previous-page)
     (define-key map [left] 'epresent-previous-page)
     (define-key map [backspace] 'epresent-previous-page)
+    (define-key map "v" 'epresent-jump-to-page)
     ;; within page functions
     (define-key map "c" 'epresent-next-src-block)
     (define-key map "C" 'epresent-previous-src-block)


### PR DESCRIPTION
Fixes #28.

This adds page numbers (shown in the mode-line by default) and a
function (bound to "v") that jumps to the given page number.