### PR TITLE
Adjust frame text size, rather than buffer.

### DIFF
--- a/epresent.el
+++ b/epresent.el
@@ -75,7 +75,7 @@
 (defvar epresent--org-file nil
   "Temporary Org-mode file used when a narrowed region.")
 
-(defvar epresent-text-scale 3)
+(defvar epresent-text-size 500)
 
 (defvar epresent-overlays nil)
 
@@ -204,8 +204,6 @@ If nil then source blocks are initially hidden on slide change.")
   "Quit the current presentation."
   (interactive)
   (run-hooks 'epresent-stop-presentation-hook)
-  ;; restore the font size
-  (text-scale-adjust (/ 1 epresent-text-scale))
   (org-remove-latex-fragment-image-overlays)
   ;; restore the user's Org-mode variables
   (remove-hook 'org-src-mode-hook 'epresent-setup-src-edit)
@@ -339,8 +337,7 @@ If nil then source blocks are initially hidden on slide change.")
   (epresent-fontify))
 
 (defun epresent-setup-src-edit ()
-  (setq cursor-type 'box)
-  (text-scale-adjust epresent-text-scale))
+  (setq cursor-type 'box))
 
 (defun epresent-flash-cursor ()
   (setq cursor-type 'hollow)
@@ -436,8 +433,6 @@ If nil then source blocks are initially hidden on slide change.")
 
 (define-derived-mode epresent-mode org-mode "EPresent"
   "Lalala."
-  (text-scale-adjust 0)
-  (text-scale-adjust epresent-text-scale)
   ;; make Org-mode be as pretty as possible
   (add-hook 'org-src-mode-hook 'epresent-setup-src-edit)
   (setq epresent-inline-image-overlays org-inline-image-overlays)
@@ -457,6 +452,7 @@ If nil then source blocks are initially hidden on slide change.")
          (plist-put (copy-tree org-format-latex-options)
 		    :scale epresent-format-latex-scale)))
     (org-preview-latex-fragment '(16)))
+  (set-face-attribute 'default epresent--frame :height epresent-text-size)
   ;; fontify the buffer
   (add-to-invisibility-spec '(epresent-hide))
   ;; remove flyspell overlays


### PR DESCRIPTION
This allows the mode-line to scale along with the text. It also means we
only have to set the size when we create the frame, and it doesn’t
affect any other windows containing the org buffer.

This also switches from a relative scale to an absolute size (in 1/10
pt). I was having trouble figuring out what the scaling should be, and
also don’t see any connection between the size I like to edit and the
size that should be presented to an audience. I set the default to 50
pt, since that seems to be a common default in various presentation software.