### PR TITLE
Avoid redrawing everything on every page change

### DIFF
--- a/epresent.el
+++ b/epresent.el
@@ -497,7 +497,7 @@ If nil then source blocks are initially hidden on slide change."
         (while (re-search-forward org-babel-src-block-regexp nil t)
           (goto-char (1- (match-end 5)))
           (toggle))))
-    (redraw-display)))
+    (redraw-frame)))
 
 (defun epresent-toggle-hide-src-block (&optional arg)
   (interactive "P")


### PR DESCRIPTION
By running (redraw-display), we cause a noticeable flicker in /all/ open Emacs
frames, which, while not catastrophic, is a bit of a rough edge.

If we instead redraw only the currently selected frame, we still cause a brief
flash in the presenting frame, but not in any other frames.

My current workaround for this is to add advice around redraw-display and simply
run redraw-frame instead if the major mode is epresent-mode, like-a-so:

```elisp
(define-advice redraw-display
      (:around (actual-redraw &rest args) epresent-only-redisplay-frame)
    (if (eq major-mode 'epresent-mode)
        (apply 'redraw-frame (cons nil args))
      (apply actual-redraw args)))
```