### PR TITLE
Make sure the presentation frame shows the intended buffer

### DIFF
--- a/epresent.el
+++ b/epresent.el
@@ -627,6 +627,7 @@ If nil then source blocks are initially hidden on slide change."
       (find-file epresent--org-file)))
   (setq epresent-frame-level (epresent-get-frame-level))
   (epresent--get-frame)
+  (switch-to-buffer epresent--org-buffer)
   (epresent-mode)
   (set-buffer-modified-p nil)
   (run-hooks 'epresent-start-presentation-hook))


### PR DESCRIPTION
I have an after-make-frame-functions hook that switches new frames to
the *scratch* buffer, which broke epresent: it only ever showed an empty
presentation!

My current workaround is to define advice around epresent--get-frame which gets
the current buffer, calls epresent--get-frame, and then switches to the buffer,
as such:

(define-advice epresent--get-frame
      (:around (actual-get-frame &rest args) epresent-frame-set-buffer)
    (let ((presentation-buffer (current-buffer)))
      (apply actual-get-frame args)
      (switch-to-buffer presentation-buffer)
      epresent--frame))

I realised, however, that epresent-run already gets the correct buffer – it just
doesn't switch to it after creating the frame! So that's what this fix
implements.