### PR TITLE
Check that org-todo-line-regexp is set when using

### DIFF
--- a/epresent.el
+++ b/epresent.el
@@ -400,7 +400,7 @@ If nil then source blocks are initially hidden on slide change."
           '(("[ \t]+" . "∘")
             ("" . "•")))
     ;; hide todos
-    (when epresent-hide-todos
+    (when (and epresent-hide-todos org-todo-line-regexp)
       (goto-char (point-min))
       (while (re-search-forward org-todo-line-regexp nil t)
         (when (match-string 2)


### PR DESCRIPTION
This variable gets set buffer-locally by Org, but it defaults to nil and may be
nil in some cases when `epresent-fontify` is called. So this ensures it’s set
before using it as a regexp (otherwise `re-search-forward` will error.

Fixes #72.